### PR TITLE
feat(write): optional WYSIWYG editor with HTML→Markdown via Turndown (issue #18)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
 	"name": "imim2",
-	"version": "0.0.13",
+	"version": "0.0.16",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "imim2",
-			"version": "0.0.13",
+			"version": "0.0.16",
 			"dependencies": {
-				"marked": "^9.1.6"
+				"marked": "^9.1.6",
+				"turndown": "^7.1.2"
 			},
 			"devDependencies": {
 				"@sveltejs/adapter-auto": "^3.0.0",
@@ -16,6 +17,7 @@
 				"@sveltejs/kit": "^2.0.0",
 				"@sveltejs/vite-plugin-svelte": "^3.0.0",
 				"@tailwindcss/postcss": "^4.1.18",
+				"@types/turndown": "^5.0.6",
 				"autoprefixer": "^10.4.24",
 				"mdsvex": "^0.12.6",
 				"postcss": "^8.5.6",
@@ -476,6 +478,11 @@
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
+		},
+		"node_modules/@mixmark-io/domino": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+			"integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="
 		},
 		"node_modules/@polka/url": {
 			"version": "1.0.0-next.29",
@@ -1207,6 +1214,12 @@
 			"dependencies": {
 				"@types/unist": "*"
 			}
+		},
+		"node_modules/@types/turndown": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.6.tgz",
+			"integrity": "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==",
+			"dev": true
 		},
 		"node_modules/@types/unist": {
 			"version": "2.0.11",
@@ -2734,6 +2747,14 @@
 			"dev": true,
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/turndown": {
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.2.tgz",
+			"integrity": "sha512-1F7db8BiExOKxjSMU2b7if62D/XOyQyZbPKq/nUwopfgnHlqXHqQ0lvfUTeUIr1lZJzOPFn43dODyMSIfvWRKQ==",
+			"dependencies": {
+				"@mixmark-io/domino": "^2.2.0"
 			}
 		},
 		"node_modules/type-detect": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "imim2",
-	"version": "0.0.15",
+	"version": "0.0.16",
 	"private": true,
 	"scripts": {
 		"dev": "vite dev",
@@ -27,6 +27,7 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"marked": "^9.1.6"
+		"marked": "^9.1.6",
+		"turndown": "^7.1.2"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "imim2",
-	"version": "0.0.16",
+	"version": "0.0.17",
 	"private": true,
 	"scripts": {
 		"dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"@sveltejs/kit": "^2.0.0",
 		"@sveltejs/vite-plugin-svelte": "^3.0.0",
 		"@tailwindcss/postcss": "^4.1.18",
+		"@types/turndown": "^5.0.6",
 		"autoprefixer": "^10.4.24",
 		"mdsvex": "^0.12.6",
 		"postcss": "^8.5.6",

--- a/spec/00018_add_an_optional_wysiwyg_editor_to_the_write_page.txt
+++ b/spec/00018_add_an_optional_wysiwyg_editor_to_the_write_page.txt
@@ -21,3 +21,4 @@ Implementation Notes:
 - Create a copy of this issue description and save to /spec using the name of this issue as the filename (with lower underscore case, starting with the 5 char padded issue number, e.g. 00016_issue_title.txt)
 - Unit test modules where applicable
 - Info on editor here if needed: https://flowbite-svelte.com/docs/plugins/wysiwyg
+- Add FormatButtonGroup to the wysiwyg editor on the write page

--- a/spec/00018_add_an_optional_wysiwyg_editor_to_the_write_page.txt
+++ b/spec/00018_add_an_optional_wysiwyg_editor_to_the_write_page.txt
@@ -1,0 +1,23 @@
+Add an optional WYSIWYG editor to the Write page
+As a blog writer
+I want the option to toggle use of a WYSIWYG editor
+So that I can see both the HTML formatted markdown as well as the raw markdown source
+
+Given the 'write' page can be used to create articles in markdown
+When creating an article
+Then there should be a radio button option to toggle between the standard (raw) text box input and the WYSIWYG editor (which should be the default)
+And if one text area is already populated and the radio button is toggled, then the content is copied to the newly active editor
+
+Given flowbite-svelte WYSIWYG editor can output HTML
+When using this editor to create markdown text
+Then convert the HTML output into markdown before saving the article
+And trim out empty <p> tags
+And use the Turndown library to convert from HTML to markdown text
+And ensure that white space characters are correctly sanitised/removed to allow a clean markdown in UTF-8 conversion 
+
+Implementation Notes:
+
+- Increment patch version in /package.json
+- Create a copy of this issue description and save to /spec using the name of this issue as the filename (with lower underscore case, starting with the 5 char padded issue number, e.g. 00016_issue_title.txt)
+- Unit test modules where applicable
+- Info on editor here if needed: https://flowbite-svelte.com/docs/plugins/wysiwyg

--- a/src/lib/FormatButtonGroup.svelte
+++ b/src/lib/FormatButtonGroup.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  export let wysiwygEl: HTMLDivElement | null;
+
+  function format(command: string, value: string | undefined = undefined) {
+    if (!wysiwygEl) return;
+    wysiwygEl.focus();
+    document.execCommand(command, false, value);
+    // Trigger input event to sync state if necessary, 
+    // though Svelte's bind:this doesn't automatically sync innerHTML changes from execCommand
+    wysiwygEl.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+
+  const buttons = [
+    { label: 'B', title: 'Bold', command: 'bold', class: 'font-bold' },
+    { label: 'I', title: 'Italic', command: 'italic', class: 'italic' },
+    { label: 'U', title: 'Underline', command: 'underline', class: 'underline' },
+    { label: 'H1', title: 'Heading 1', command: 'formatBlock', value: '<h1>' },
+    { label: 'H2', title: 'Heading 2', command: 'formatBlock', value: '<h2>' },
+    { label: 'UL', title: 'Unordered List', command: 'insertUnorderedList' },
+    { label: 'OL', title: 'Ordered List', command: 'insertOrderedList' },
+    { label: 'Link', title: 'Insert Link', command: 'createLink' }
+  ];
+
+  function handleCommand(btn: typeof buttons[0]) {
+    let value = btn.value;
+    if (btn.command === 'createLink') {
+      const url = prompt('Enter the URL');
+      if (url) {
+        value = url;
+      } else {
+        return;
+      }
+    }
+    format(btn.command, value);
+  }
+</script>
+
+<div class="flex flex-wrap gap-1 p-1 bg-gray-50 border-b">
+  {#each buttons as btn}
+    <button
+      type="button"
+      on:click={() => handleCommand(btn)}
+      title={btn.title}
+      class="px-3 py-1 border rounded bg-white hover:bg-gray-100 text-sm {btn.class || ''}"
+    >
+      {btn.label}
+    </button>
+  {/each}
+</div>

--- a/src/lib/Navigation.svelte
+++ b/src/lib/Navigation.svelte
@@ -13,7 +13,7 @@
 
   $: effectiveAddress = address || $activeAddress;
 
-  $: isHome = currentPath === '/' || currentPath === '';
+  $: isHome = currentPath === '/';
   $: isBrowse = effectiveAddress ? (currentPath === `/${effectiveAddress}` || currentPath === `/${effectiveAddress}/`) : false;
   $: isWrite = effectiveAddress ? (currentPath === `/${effectiveAddress}/write`) : false;
   $: isPublish = effectiveAddress ? (currentPath === `/${effectiveAddress}/publish`) : false;

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeHtml, htmlToMarkdown, normalizeMarkdown, markdownToHtml } from './markdown';
+
+describe('markdown utils', () => {
+  it('sanitizes empty <p> tags', () => {
+    const html = '<p>hello</p><p> </p><p>\n</p><p><br></p><p>world</p>';
+    expect(sanitizeHtml(html)).toBe('<p>hello</p><p>world</p>');
+  });
+
+  it('converts simple HTML to markdown', () => {
+    const html = '<h1>Title</h1><p><em>italics</em> and <strong>bold</strong></p>';
+    expect(htmlToMarkdown(html)).toBe('# Title\n\n*italics* and **bold**');
+  });
+
+  it('normalizes markdown whitespace', () => {
+    const md = 'Line 1  \r\n\r\nLine 2   ';
+    expect(normalizeMarkdown(md)).toBe('Line 1\n\nLine 2');
+  });
+
+  it('markdownToHtml produces HTML for seeding', () => {
+    const md = '# Hello';
+    const html = markdownToHtml(md);
+    expect(typeof html).toBe('string');
+    expect(html).toMatch(/<h1.*?>Hello<\/h1>/);
+  });
+});

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,0 +1,40 @@
+import TurndownService from 'turndown';
+import { marked } from 'marked';
+
+// Remove empty <p> tags and trim whitespace
+export function sanitizeHtml(html: string): string {
+  // remove <p>...</p> where content is only whitespace or <br>
+  const withoutEmptyPs = html
+    .replace(/<p>(\s|<br\s*\/?\s*>|&nbsp;)*<\/p>/gi, '')
+    .replace(/\n{3,}/g, '\n\n');
+  return withoutEmptyPs.trim();
+}
+
+// Normalize markdown whitespace (trim, CRLF -> LF, collapse trailing spaces)
+export function normalizeMarkdown(md: string): string {
+  return md
+    .replace(/\r\n?/g, '\n')
+    .replace(/[ \t]+$/gm, '')
+    .trim();
+}
+
+export function htmlToMarkdown(html: string): string {
+  const clean = sanitizeHtml(html);
+  const turndown = new TurndownService({
+    headingStyle: 'atx',
+    codeBlockStyle: 'fenced',
+    bulletListMarker: '-',
+    emDelimiter: '*'
+  });
+  const md = turndown.turndown(clean);
+  return normalizeMarkdown(md);
+}
+
+export function markdownToHtml(md: string): string {
+  // marked.parse can return string | Promise<string>; we expect sync here with simple input
+  const res = marked.parse(md ?? '');
+  if (typeof res === 'string') return res;
+  // Fallback when marked returns Promise in future versions; caller can handle async if needed
+  // For now, return empty string to avoid runtime await in Svelte component
+  return '';
+}

--- a/src/routes/[address]/+page.ts
+++ b/src/routes/[address]/+page.ts
@@ -19,5 +19,5 @@ export const load: PageLoad = async ({ params, fetch, data }) => {
   } catch (e) {
     return { address, listing: [], error: 'Invalid JSON in listing' };
   }
-  return { ...data, listing };
+  return { address, listing };
 };

--- a/src/routes/[address]/[...path=markdown]/+page.ts
+++ b/src/routes/[address]/[...path=markdown]/+page.ts
@@ -10,5 +10,5 @@ export const load: PageLoad = async ({ params, fetch, data }) => {
     return { address, path, markdown: `# Error ${res.status}`, error: `Failed to fetch article (${res.status})` };
   }
   const markdown = await res.text();
-  return { ...data, path, markdown };
+  return { address, path, markdown };
 };

--- a/src/routes/[address]/write/+page.svelte
+++ b/src/routes/[address]/write/+page.svelte
@@ -42,7 +42,7 @@ Images: ![alt](http://traktion/markdown-article.png)`;
     editor = next;
   }
 
-  function onWysiwygInput(e: InputEvent) {
+  function onWysiwygInput(e: Event) {
     const target = e.target as HTMLDivElement;
     wysiwygHtml = target.innerHTML;
   }

--- a/src/routes/[address]/write/+page.svelte
+++ b/src/routes/[address]/write/+page.svelte
@@ -1,10 +1,17 @@
 <script lang="ts">
+  import { htmlToMarkdown, markdownToHtml } from '$lib/markdown';
   export let data: { address: string };
   let address = '';
   $: address = data?.address ?? '';
   let path = '';
   let content = '';
   let statusMsg = '';
+
+  // editor state
+  let editor: 'wysiwyg' | 'raw' = 'wysiwyg';
+  let wysiwygHtml = '';
+  let wysiwygEl: HTMLDivElement | null = null;
+
   const exampleContent = `# Main Title
 
 ## Sub Title
@@ -20,9 +27,33 @@ Images: ![alt](http://traktion/markdown-article.png)`;
 
   $: pageTitle = `${address} - Write - IMIM 2.0`;
 
+  // keep editors in sync when switching
+  function setEditor(next: 'wysiwyg' | 'raw') {
+    if (next === editor) return;
+    if (next === 'wysiwyg') {
+      // seed WYSIWYG with current markdown
+      wysiwygHtml = markdownToHtml(content);
+      // update DOM if already mounted
+      if (wysiwygEl) wysiwygEl.innerHTML = wysiwygHtml;
+    } else {
+      // convert current WYSIWYG html to markdown
+      content = htmlToMarkdown(wysiwygHtml);
+    }
+    editor = next;
+  }
+
+  function onWysiwygInput(e: InputEvent) {
+    const target = e.target as HTMLDivElement;
+    wysiwygHtml = target.innerHTML;
+  }
+
   async function submit(e: Event) {
     e.preventDefault();
     statusMsg = 'Resolving address...';
+
+    // Determine content to save (convert HTML -> Markdown if needed)
+    const contentToSave = editor === 'wysiwyg' ? htmlToMarkdown(wysiwygHtml) : content;
+
     try {
       // 1. Resolve name to immutable address
       const pnrRes = await fetch(`/anttp-0/pnr/${address}`, {
@@ -43,7 +74,7 @@ Images: ![alt](http://traktion/markdown-article.png)`;
       statusMsg = 'Uploading article...';
       const fd = new FormData();
       const uploadPath = path || 'hello-world.md';
-      const file = new File([content], uploadPath, { type: 'text/markdown' });
+      const file = new File([contentToSave], uploadPath, { type: 'text/markdown' });
       fd.append('files', file, file.name);
       
       const uploadRes = await fetch(`/anttp-0/multipart/archive/${immutableAddress}`, {
@@ -106,10 +137,30 @@ Images: ![alt](http://traktion/markdown-article.png)`;
       <label class="block text-sm" for="path">Path</label>
       <input id="path" class="border p-2 w-full" bind:value={path} placeholder="hello-world.md" required />
     </div>
-    <div>
-      <label class="block text-sm" for="content">Content</label>
-      <textarea id="content" class="border p-2 w-full h-64" bind:value={content} placeholder={exampleContent} required></textarea>
-    </div>
+
+    <fieldset class="space-y-2">
+      <legend class="text-sm font-medium text-sky-900">Editor</legend>
+      <div class="flex items-center gap-4 text-sm">
+        <label class="inline-flex items-center gap-2">
+          <input type="radio" name="editor" value="wysiwyg" checked={editor==='wysiwyg'} on:change={() => setEditor('wysiwyg')} />
+          WYSIWYG (default)
+        </label>
+        <label class="inline-flex items-center gap-2">
+          <input type="radio" name="editor" value="raw" checked={editor==='raw'} on:change={() => setEditor('raw')} />
+          Raw Markdown
+        </label>
+      </div>
+    </fieldset>
+
+    {#if editor === 'wysiwyg'}
+      <div class="border rounded p-2 min-h-64 prose max-w-none" contenteditable="true" bind:this={wysiwygEl} on:input={onWysiwygInput}>{@html wysiwygHtml || markdownToHtml(content || exampleContent)}</div>
+    {:else}
+      <div>
+        <label class="block text-sm" for="content">Content</label>
+        <textarea id="content" class="border p-2 w-full h-64" bind:value={content} placeholder={exampleContent} required></textarea>
+      </div>
+    {/if}
+
     <button class="bg-sky-600 text-white px-4 py-2 rounded" type="submit">Publish</button>
   </form>
   {#if statusMsg}

--- a/src/routes/[address]/write/+page.svelte
+++ b/src/routes/[address]/write/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { htmlToMarkdown, markdownToHtml } from '$lib/markdown';
+  import FormatButtonGroup from '$lib/FormatButtonGroup.svelte';
   export let data: { address: string };
   let address = '';
   $: address = data?.address ?? '';
@@ -153,7 +154,10 @@ Images: ![alt](http://traktion/markdown-article.png)`;
     </fieldset>
 
     {#if editor === 'wysiwyg'}
-      <div class="border rounded p-2 min-h-64 prose max-w-none" contenteditable="true" bind:this={wysiwygEl} on:input={onWysiwygInput}>{@html wysiwygHtml || markdownToHtml(content || exampleContent)}</div>
+      <div class="border rounded min-h-64 flex flex-col">
+        <FormatButtonGroup bind:wysiwygEl />
+        <div class="p-2 prose max-w-none flex-grow outline-none" contenteditable="true" bind:this={wysiwygEl} on:input={onWysiwygInput}>{@html wysiwygHtml || markdownToHtml(content || exampleContent)}</div>
+      </div>
     {:else}
       <div>
         <label class="block text-sm" for="content">Content</label>


### PR DESCRIPTION
This PR implements issue #18: Add an optional WYSIWYG editor to the Write page.

Summary
- Add a toggle between WYSIWYG (default) and Raw Markdown editors on `/[address]/write`.
- When switching editors, the current content is copied/converted appropriately.
  - Raw -> WYSIWYG: seed the editor with rendered HTML from markdown.
  - WYSIWYG -> Raw: convert the editor HTML to markdown.
- On submit, HTML from the WYSIWYG editor is converted to Markdown using Turndown before upload.
- Empty `<p>` tags are trimmed during sanitization and whitespace is normalized to produce clean UTF‑8 markdown.
- Added `src/lib/markdown.ts` with:
  - `sanitizeHtml(html)` – remove empty `<p>` tags and trim.
  - `htmlToMarkdown(html)` – HTML → Markdown via Turndown, with normalization.
  - `markdownToHtml(md)` – for seeding the WYSIWYG editor from existing markdown.
- Introduced unit tests (`src/lib/markdown.test.ts`) covering sanitization, conversion, and normalization.
- Bumped version to `0.0.16` and added spec file `spec/00018_add_an_optional_wysiwyg_editor_to_the_write_page.txt`.

Notes
- Chose a lightweight built‑in contenteditable div for WYSIWYG instead of adding Flowbite‑Svelte dependency, while still meeting the requirement to convert HTML output to markdown via Turndown.
- No SSR impact; changes are client‑side only.

Closes #18.