### PR TITLE
Refactor comments to use key/value API (#28)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "imim2",
-	"version": "0.0.21",
+	"version": "0.0.22",
 	"private": true,
 	"scripts": {
 		"dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "imim2",
-	"version": "0.0.20",
+	"version": "0.0.21",
 	"private": true,
 	"scripts": {
 		"dev": "vite dev",

--- a/spec/00028_replace_graph_entry_based_comments_with_key_value_api_implementation.txt
+++ b/spec/00028_replace_graph_entry_based_comments_with_key_value_api_implementation.txt
@@ -1,0 +1,18 @@
+As a software engineer
+I want comments to be driven using AntTP's key/value endpoints instead of using a combination of public data and graph entries calls
+So that the implementation is simpler and more flexible
+
+Given comments are currently created by a POST to /anttp-0/binary/public_data and then a POST to /anttp-0/graph_entry
+When refactoring to use the key/value endpoint
+Then replace both calls with a single POST /anttp-0/binary/key_value/{commentKey}/msg1 with the comment text in the application/octet-stream body (the same body as POST to /anttp-0/binary/public_data before)
+
+Given comments are currently read by calling GET /anttp-0/graph_entry/${commentKey} and then GET /anttp-0/binary/public_data/${result.address}
+When refactoring to use key/value endpoint
+Then replace both calls with a single GET /anttp-0/binary/key_value/{commentKey}/msg1 to retrieve both data items
+And get comment text from the application/octet-stream response body (the same response as GET /anttp-0/binary/public_data return before)
+
+Implementation Notes
+
+- Increment patch version in /package.json
+- Create a copy of this issue description and save to /spec using the name of this issue as the filename (with lower underscore case, starting with the 5 char padded issue number, e.g. 00016_issue_title.txt)
+- Unit test modules where applicable

--- a/src/lib/comments.test.ts
+++ b/src/lib/comments.test.ts
@@ -6,10 +6,7 @@ describe('comments utility', () => {
     it('successfully publishes a comment', async () => {
       const mockFetch = vi.fn()
         .mockImplementation(async (url, init) => {
-          if (url === '/anttp-0/binary/public_data') {
-            return { ok: true, json: async () => ({ address: 'new_addr' }) };
-          }
-          if (url === '/anttp-0/graph_entry') {
+          if (url === '/anttp-0/binary/key_value/imim_blog_article_comment1/msg1') {
             return { ok: true };
           }
           return { ok: false };
@@ -17,25 +14,18 @@ describe('comments utility', () => {
 
       const result = await publishComment('blog', 'article.md', 'Hello', 0, mockFetch as any);
       expect(result.success).toBe(true);
-      expect(mockFetch).toHaveBeenCalledWith('/anttp-0/binary/public_data', expect.objectContaining({
+      expect(mockFetch).toHaveBeenCalledWith('/anttp-0/binary/key_value/imim_blog_article_comment1/msg1', expect.objectContaining({
         method: 'POST',
+        headers: { 'Content-Type': 'application/octet-stream' },
         body: 'Hello'
-      }));
-      expect(mockFetch).toHaveBeenCalledWith('/anttp-0/graph_entry', expect.objectContaining({
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'x-data-key': 'resolver' },
-        body: JSON.stringify({
-          content: 'new_addr',
-          name: 'imim_blog_article_comment1'
-        })
       }));
     });
 
-    it('handles failure in public data creation', async () => {
+    it('handles failure in comment creation', async () => {
       const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 500, text: async () => 'Error' });
       const result = await publishComment('blog', 'article.md', 'Hello', 0, mockFetch as any);
       expect(result.success).toBe(false);
-      expect(result.error).toContain('Failed to create public data');
+      expect(result.error).toContain('Failed to create comment');
       expect(result.error).toContain('500 Error');
     });
   });
@@ -83,16 +73,10 @@ describe('comments utility', () => {
   it('fetches comments in batches and calls onComment', async () => {
     const mockFetch = vi.fn()
       .mockImplementation(async (url) => {
-        if (url === '/anttp-0/graph_entry/imim_blog_article_comment1') {
-          return { ok: true, json: async () => ({ content: 'addr1' }) };
-        }
-        if (url === '/anttp-0/binary/public_data/addr1') {
+        if (url === '/anttp-0/binary/key_value/imim_blog_article_comment1/msg1') {
           return { ok: true, text: async () => 'Comment 1' };
         }
-        if (url === '/anttp-0/graph_entry/imim_blog_article_comment2') {
-          return { ok: true, json: async () => ({ content: 'addr2' }) };
-        }
-        if (url === '/anttp-0/binary/public_data/addr2') {
+        if (url === '/anttp-0/binary/key_value/imim_blog_article_comment2/msg1') {
           return { ok: true, text: async () => 'Comment 2' };
         }
         return { ok: false, status: 404 };
@@ -100,47 +84,19 @@ describe('comments utility', () => {
 
     const receivedComments: any[] = [];
     await getComments('blog', 'article.md', (c) => {
-      // Find and update or add
-      const idx = receivedComments.findIndex(rc => rc.address === c.address);
-      if (idx !== -1) {
-        receivedComments[idx] = { ...c };
-      } else {
-        receivedComments.push({ ...c });
-      }
+      receivedComments.push({ ...c });
     }, mockFetch as any);
     
-    // We expect 2 comments eventually
-    // Since fetches are async, we might need to wait for them. 
-    // In a test with vi.fn() that returns resolved promises, they will resolve in the next microtick.
-    // But getComments itself is async and we awaited it. 
-    // Wait, getComments now finishes graph entries, but the public_data fetches might still be pending.
+    expect(receivedComments).toHaveLength(2);
+    expect(receivedComments[0].text).toBe('Comment 1');
+    expect(receivedComments[0].loading).toBe(false);
+    expect(receivedComments[1].text).toBe('Comment 2');
+    expect(receivedComments[1].loading).toBe(false);
     
-    // Let's use a small helper to wait for the expected state
-    const waitFor = async (fn: () => void, timeout = 1000) => {
-      const start = Date.now();
-      while (Date.now() - start < timeout) {
-        try {
-          fn();
-          return;
-        } catch (e) {
-          await new Promise(r => setTimeout(r, 10));
-        }
-      }
-      fn(); // Final attempt to throw
-    };
-
-    await waitFor(() => {
-      expect(receivedComments).toHaveLength(2);
-      expect(receivedComments[0].text).toBe('Comment 1');
-      expect(receivedComments[0].loading).toBe(false);
-      expect(receivedComments[1].text).toBe('Comment 2');
-      expect(receivedComments[1].loading).toBe(false);
-    });
-    
-    // It should have tried to fetch 2 graph entries for the first batch
-    expect(mockFetch).toHaveBeenCalledWith('/anttp-0/graph_entry/imim_blog_article_comment1', expect.anything());
-    expect(mockFetch).toHaveBeenCalledWith('/anttp-0/graph_entry/imim_blog_article_comment2', expect.anything());
-    // Since we found addr2 at comment2, it should continue to the next batch
-    expect(mockFetch).toHaveBeenCalledWith('/anttp-0/graph_entry/imim_blog_article_comment3', expect.anything());
+    // It should have tried to fetch 2 entries for the first batch
+    expect(mockFetch).toHaveBeenCalledWith('/anttp-0/binary/key_value/imim_blog_article_comment1/msg1', expect.anything());
+    expect(mockFetch).toHaveBeenCalledWith('/anttp-0/binary/key_value/imim_blog_article_comment2/msg1', expect.anything());
+    // Since we found comment2, it should continue to the next batch
+    expect(mockFetch).toHaveBeenCalledWith('/anttp-0/binary/key_value/imim_blog_article_comment3/msg1', expect.anything());
   });
 });

--- a/src/lib/comments.test.ts
+++ b/src/lib/comments.test.ts
@@ -89,8 +89,10 @@ describe('comments utility', () => {
     
     expect(receivedComments).toHaveLength(2);
     expect(receivedComments[0].text).toBe('Comment 1');
+    expect(receivedComments[0].address).toBe('imim_blog_article_comment1');
     expect(receivedComments[0].loading).toBe(false);
     expect(receivedComments[1].text).toBe('Comment 2');
+    expect(receivedComments[1].address).toBe('imim_blog_article_comment2');
     expect(receivedComments[1].loading).toBe(false);
     
     // It should have tried to fetch 2 entries for the first batch

--- a/src/lib/comments.ts
+++ b/src/lib/comments.ts
@@ -63,35 +63,16 @@ export async function publishComment(
   fetchFn: typeof fetch = fetch
 ): Promise<{ success: boolean; error?: string }> {
   try {
-    // 1. Create public data
-    const publicDataRes = await fetchFn('/anttp-0/binary/public_data', {
+    const commentKey = getCommentKey(address, path, currentIndex + 1);
+    const res = await fetchFn(`/anttp-0/binary/key_value/${commentKey}/msg1`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/octet-stream' },
       body: commentText
     });
 
-    if (!publicDataRes.ok) {
-      const errorText = await publicDataRes.text().catch(() => 'No error body');
-      return { success: false, error: `Failed to create public data: ${publicDataRes.status} ${errorText}` };
-    }
-
-    const publicData = await publicDataRes.json();
-    const contentAddress = publicData.address;
-
-    // 2. Create graph entry
-    const commentKey = getCommentKey(address, path, currentIndex + 1);
-    const graphEntryRes = await fetchFn('/anttp-0/graph_entry', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'x-data-key': 'resolver' },
-      body: JSON.stringify({
-        content: contentAddress,
-        name: commentKey
-      })
-    });
-
-    if (!graphEntryRes.ok) {
-      const errorText = await graphEntryRes.text().catch(() => 'No error body');
-      return { success: false, error: `Failed to create graph entry: ${graphEntryRes.status} ${errorText}` };
+    if (!res.ok) {
+      const errorText = await res.text().catch(() => 'No error body');
+      return { success: false, error: `Failed to create comment: ${res.status} ${errorText}` };
     }
 
     return { success: true };
@@ -114,53 +95,34 @@ export async function getComments(
     const batchIndices = Array.from({ length: BATCH_SIZE }, (_, i) => index + i);
     let foundInBatch = false;
 
-    // Fetch batch of graph entries in parallel
-    const graphPromises = batchIndices.map(async (idx) => {
+    // Fetch batch of key_value entries in parallel
+    const kvPromises = batchIndices.map(async (idx) => {
       const commentKey = getCommentKey(address, path, idx);
-      const res = await fetchFn(`/anttp-0/graph_entry/${commentKey}`, {
+      const res = await fetchFn(`/anttp-0/binary/key_value/${commentKey}/msg1`, {
         headers: { 
-          'accept': 'application/json',
-          'x-data-key': 'resolver'
+          'accept': 'application/octet-stream'
         }
       });
       if (res.ok) {
-        const data = await res.json();
-        return { index: idx, address: data.content };
+        const text = await res.text();
+        return { index: idx, text, found: true };
       }
-      return { index: idx, address: null };
+      return { index: idx, text: '', found: false };
     });
 
-    const graphResults = await Promise.all(graphPromises);
+    const kvResults = await Promise.all(kvPromises);
     
     // Sort by index to maintain order
-    graphResults.sort((a, b) => a.index - b.index);
+    kvResults.sort((a, b) => a.index - b.index);
 
-    for (const result of graphResults) {
-      if (result.address) {
+    for (const result of kvResults) {
+      if (result.found) {
         foundInBatch = true;
-        // Create a placeholder comment in loading state
-        const comment: Comment = { text: '', address: result.address, loading: true };
+        // Directly notify the comment text
+        const comment: Comment = { text: result.text, address: '', loading: false };
         onComment(comment);
-
-        // Fetch the data asynchronously without awaiting it here
-        fetchFn(`/anttp-0/binary/public_data/${result.address}`).then(async (dataRes) => {
-          if (dataRes.ok) {
-            comment.text = await dataRes.text();
-          } else {
-            // Requirement says "hide comment text elements which return no data"
-            comment.text = '';
-          }
-          comment.loading = false;
-          onComment(comment); // Notify update
-        }).catch(() => {
-          comment.loading = false;
-          comment.text = '';
-          onComment(comment);
-        });
       } else {
-        // If we hit a gap, we assume no more comments? 
-        // Sequential requirement from previous issue: "repeat until there are no matches"
-        // So first null means end.
+        // If we hit a gap, we assume no more comments
         return; 
       }
     }

--- a/src/lib/comments.ts
+++ b/src/lib/comments.ts
@@ -119,7 +119,8 @@ export async function getComments(
       if (result.found) {
         foundInBatch = true;
         // Directly notify the comment text
-        const comment: Comment = { text: result.text, address: '', loading: false };
+        const commentKey = getCommentKey(address, path, result.index);
+        const comment: Comment = { text: result.text, address: commentKey, loading: false };
         onComment(comment);
       } else {
         // If we hit a gap, we assume no more comments


### PR DESCRIPTION
Refactored the comment system to use AntTP's key/value API instead of the previous combination of public data and graph entries.

Key changes:
- `publishComment` now uses `POST /anttp-0/binary/key_value/{commentKey}/msg1`.
- `getComments` now uses `GET /anttp-0/binary/key_value/{commentKey}/msg1`.
- Incremented patch version in `package.json` to `0.0.21`.
- Added spec file `spec/00028_replace_graph_entry_based_comments_with_key_value_api_implementation.txt`.
- Updated unit tests in `src/lib/comments.test.ts`.

Closes #28